### PR TITLE
Fix code scanning alert no. 809: Potential use after free

### DIFF
--- a/deps/openssl/openssl/ssl/statem/extensions_clnt.c
+++ b/deps/openssl/openssl/ssl/statem/extensions_clnt.c
@@ -1657,6 +1657,8 @@ int tls_parse_stoc_alpn(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
     }
     if (!PACKET_copy_bytes(pkt, s->s3.alpn_selected, len)) {
         SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_R_BAD_EXTENSION);
+        OPENSSL_free(s->s3.alpn_selected);
+        s->s3.alpn_selected = NULL;
         return 0;
     }
     s->s3.alpn_selected_len = len;


### PR DESCRIPTION
Fixes [https://github.com/Dargon789/node/security/code-scanning/809](https://github.com/Dargon789/node/security/code-scanning/809)

To fix the problem, we need to ensure that `s->s3.alpn_selected` is not accessed if the memory allocation fails. This can be achieved by adding a check to ensure that the pointer is not used after it has been freed and before it has been successfully reallocated.

- We will add a check after the memory allocation to ensure that the pointer is not accessed if the allocation fails.
- Specifically, we will add a return statement after the allocation failure check to prevent further execution if the allocation fails.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Fix a potential use-after-free vulnerability by ensuring that the pointer 's->s3.alpn_selected' is set to NULL after being freed.