### PR TITLE
Potential fix for code scanning alert no. 809: Potential use after free

### DIFF
--- a/deps/openssl/openssl/ssl/statem/extensions_clnt.c
+++ b/deps/openssl/openssl/ssl/statem/extensions_clnt.c
@@ -1663,7 +1663,8 @@ int tls_parse_stoc_alpn(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
     }
     s->s3.alpn_selected_len = len;
 
-    if (s->session->ext.alpn_selected == NULL
+    if (s->s3.alpn_selected == NULL
+            || s->session->ext.alpn_selected == NULL
             || s->session->ext.alpn_selected_len != len
             || memcmp(s->session->ext.alpn_selected, s->s3.alpn_selected, len)
                != 0) {


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/node/security/code-scanning/809](https://github.com/Dargon789/node/security/code-scanning/809)

To fix the potential use-after-free error, we need to ensure that `s->s3.alpn_selected` is not used if it is `NULL`. This can be done by adding a check before the usage of `s->s3.alpn_selected` at line 1668. If `s->s3.alpn_selected` is `NULL`, we should handle it appropriately, possibly by returning an error.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Address potential use-after-free vulnerability in `tls_parse_stoc_alpn` by checking for a NULL `alpn_selected` value before use.