### PR TITLE
Potential fix for code scanning alert no. 895: Shell command built from environment values

### DIFF
--- a/deps/cjs-module-lexer/src/build/wasm.js
+++ b/deps/cjs-module-lexer/src/build/wasm.js
@@ -4,7 +4,7 @@ const WASM_BUILDER_CONTAINER = 'ghcr.io/nodejs/wasm-builder@sha256:975f391d907e4
 
 const WASM_OPT = './wasm-opt'
 
-const { execSync } = require('node:child_process')
+const { execSync, execFileSync } = require('node:child_process')
 const { writeFileSync, readFileSync, existsSync, mkdirSync } = require('node:fs')
 const { join, resolve } = require('node:path')
 
@@ -36,7 +36,8 @@ if (process.argv[2] === '--docker') {
            --mount type=bind,source=${ROOT}/include-wasm,target=/home/node/build/include-wasm \
            -t ${WASM_BUILDER_CONTAINER} node wasm.js`
   console.log(`> ${cmd}\n\n`)
-  execSync(cmd, { stdio: 'inherit' })
+  const [command, ...args] = cmd.split(' ');
+  execFileSync(command, args, { stdio: 'inherit' })
   process.exit(0)
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/node/security/code-scanning/895](https://github.com/Dargon789/node/security/code-scanning/895)

To fix the problem, we should avoid constructing the shell command as a single string and instead use the `execFileSync` function, which allows us to pass the command and its arguments separately. This approach ensures that the arguments are not interpreted by the shell, thus preventing any unintended behavior caused by special characters.

We will:
1. Split the `cmd` string into the command and its arguments.
2. Use `execFileSync` to execute the command with the arguments passed as an array.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
